### PR TITLE
Added members link. Extended dropdown-nav

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -50,7 +50,7 @@ router.get("/community", function(req, res){
 		            	console.log(err);
 		          	}
 		          	else {
-		            	res.render("community", {users:allUsers, mods:allMods, currentUser:req.user});
+		            	res.render("community", {users:allUsers, mods:allMods, currentUser:req.user, headerActive: "community"});
           			}
 	        	});
         	}

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -160,6 +160,16 @@
 			color: #777;
 		}
 
+		/* This will auto-drop down the dropboxes when hovering in navbar button*/
+		/* ul.nav li.dropdown:hover > ul.dropdown-menu {
+			display: block;    
+		} */
+		
+		.dropdown-nav{
+			width: 100%;
+			text-align: left;
+			padding: 10px 10px;
+		}
 
 
 	</style>
@@ -214,6 +224,13 @@
 						<button class="dropdown-nav" type="button" id="community-dropdown" data-toggle="dropdown">Community<span class="caret"></span></button>
 
 						<ul class="dropdown-menu">
+							<!-- Members -->
+							<% if(headerActive === "community"){ %>
+								<li class="active"><a href="/community">Members</a></li>
+								<%} %>
+								<% if(headerActive !== "community"){ %>
+								<li><a href="/community">Members</a></li>
+								<% } %>
 
 							<!-- Forums -->
 							<% if(headerActive === "forums"){ %>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -244,8 +244,8 @@
 
 					<!-- Community dropdown -->
 					<li class="dropdown">
-						<a href="#" class="dropdown-toggle wideNavbarLink" data-toggle="" role="button" aria-haspopup="true" aria-expanded="false">Community <span class="caret"></span></a>
-						<a href="#" class="dropdown-toggle narrowNavbarLink" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Community <span class="caret"></span></a>
+						<a class="dropdown-toggle wideNavbarLink" data-toggle="" role="button" aria-haspopup="true" aria-expanded="false">Community <span class="caret"></span></a>
+						<a class="dropdown-toggle narrowNavbarLink" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Community <span class="caret"></span></a>
 
 						<ul class="dropdown-menu">
 							<!-- Members -->
@@ -270,8 +270,8 @@
 
 					<!-- Development dropdown -->
 					<li class="dropdown">
-						<a href="#" class="dropdown-toggle wideNavbarLink" data-toggle="" role="button" aria-haspopup="true" aria-expanded="false">Development <span class="caret"></span></a>
-						<a href="#" class="dropdown-toggle narrowNavbarLink" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Development <span class="caret"></span></a>
+						<a class="dropdown-toggle wideNavbarLink" data-toggle="" role="button" aria-haspopup="true" aria-expanded="false">Development <span class="caret"></span></a>
+						<a class="dropdown-toggle narrowNavbarLink" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Development <span class="caret"></span></a>
 
 						<ul class="dropdown-menu">
 							<!-- Log -->

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -151,25 +151,48 @@
 			/* margin: auto;*/
 
 		}
+		@media screen and (min-width:768px){
+			.wideNavbarLink{
+				display: block !important;
+			}
+			.narrowNavbarLink{
+				display: none !important;
+			}
 
-		.dropdown-nav {
+			.dropdown:hover .dropdown-menu {
+				display: block;
+				margin-top: 0; // remove the gap so it doesn't close
+			}
+		}
+
+		@media screen and (max-width:768px){
+			.wideNavbarLink{
+				display: none !important;
+			}
+			.narrowNavbarLink{
+				display: block !important;
+			}
+		}
+
+		
+		/* .dropdown-nav {
 			border: none;
 			background: none;
 			margin: 0;
 			padding: 15px 10px;
 			color: #777;
-		}
+		} */
 
 		/* This will auto-drop down the dropboxes when hovering in navbar button*/
 		/* ul.nav li.dropdown:hover > ul.dropdown-menu {
 			display: block;    
 		} */
-		
+/* 		
 		.dropdown-nav{
 			width: 100%;
 			text-align: left;
-			padding: 10px 10px;
-		}
+			/* padding: 10px 10px; */
+		/*} */
 
 
 	</style>
@@ -221,7 +244,8 @@
 
 					<!-- Community dropdown -->
 					<li class="dropdown">
-						<button class="dropdown-nav" type="button" id="community-dropdown" data-toggle="dropdown">Community<span class="caret"></span></button>
+						<a href="#" class="dropdown-toggle wideNavbarLink" data-toggle="" role="button" aria-haspopup="true" aria-expanded="false">Community <span class="caret"></span></a>
+						<a href="#" class="dropdown-toggle narrowNavbarLink" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Community <span class="caret"></span></a>
 
 						<ul class="dropdown-menu">
 							<!-- Members -->
@@ -246,7 +270,8 @@
 
 					<!-- Development dropdown -->
 					<li class="dropdown">
-						<button class="dropdown-nav" type="button" id="dev-dropdown" data-toggle="dropdown">Development<span class="caret"></span></button>
+						<a href="#" class="dropdown-toggle wideNavbarLink" data-toggle="" role="button" aria-haspopup="true" aria-expanded="false">Development <span class="caret"></span></a>
+						<a href="#" class="dropdown-toggle narrowNavbarLink" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Development <span class="caret"></span></a>
 
 						<ul class="dropdown-menu">
 							<!-- Log -->

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -173,27 +173,28 @@
 				display: block !important;
 			}
 		}
-
 		
-		/* .dropdown-nav {
-			border: none;
-			background: none;
-			margin: 0;
-			padding: 15px 10px;
+		li a:focus {
+			outline: none;
+		}
+
+		.dropdown-menu > .active > a, .dropdown-menu > .active > a:focus, .dropdown-menu > .active > a:hover {
+			background-color: #e7e7e7;
+			color: #555;
+		}
+
+		nav a:hover, .navbar-default .navbar-nav > li > a:focus, .navbar-default .navbar-nav > li > a:hover,
+		.dropdown-menu > li > a:hover {
+			background-color: #e7e7e7;
+			color: #555;
+		}
+
+		.dropdown-menu > li > a {
 			color: #777;
-		} */
-
-		/* This will auto-drop down the dropboxes when hovering in navbar button*/
-		/* ul.nav li.dropdown:hover > ul.dropdown-menu {
-			display: block;    
-		} */
-/* 		
-		.dropdown-nav{
-			width: 100%;
-			text-align: left;
-			/* padding: 10px 10px; */
-		/*} */
-
+		}
+		.dropdown-menu > li > a:hover {
+			color: #555;
+		}
 
 	</style>
 


### PR DESCRIPTION
Added in members link under community tab.

Also extended dropdown-nav box width so that mobile users don't have to just press the text, but anywhere along that horizontal area.

The only thing left is perhaps to make it on desktop, expand the dropdown-navs on hover. But I can't get it working reliably on mobile view...

Sorry for the delay in getting to your PR.